### PR TITLE
fix for utf8 error on comand execution

### DIFF
--- a/iwatch
+++ b/iwatch
@@ -416,6 +416,7 @@ sub mywatch {
     $command =~ /^(.+)$/;
     return if(!defined($1));
     my $securecommand = $1;
+    utf8::downgrade($securecommand) if (utf8::is_utf8($securecommand));
     system("$securecommand");
   }
   if(defined($Message) && $Path->{'alert'}) {


### PR DESCRIPTION
This pr fix an error that occour when  you pass th %f variable to a command execution, and produces an error if you put utf8 character like é á ú. 
like example below
![image](https://user-images.githubusercontent.com/25462719/81023513-02dbc180-8e47-11ea-941d-e40be821a1a4.png)

so if i put this code on iwatch all shoud. note that i'm running iwatch from my study folder

![image](https://user-images.githubusercontent.com/25462719/81023712-a2994f80-8e47-11ea-83df-cfb50415903b.png)
